### PR TITLE
fix: Broken install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install the theme with your preferred package manager:
 
 ```lua
 {
-  "electron_highlighter/nvim",
+  "electron-highlighter/nvim",
   lazy = false,
   priority = 1000,
   opts = {},


### PR DESCRIPTION
There's a typo in the lazy.nvim install instructions, which causes a confusing Github authentication error when lazy tries to install the package.

This fixes that.