### PR TITLE
Add Electron Highlighter Day (light style)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Electron Highlighter for Neovim
 
-A dark Neovim theme written in Lua ported from the excellent
+A dark and light Neovim theme written in Lua ported from the excellent
 [TokyoNight](https://github.com/folke/tokyonight.nvim) theme.
 
 ## Screenshot
@@ -12,6 +12,7 @@ A dark Neovim theme written in Lua ported from the excellent
 - supports the latest Neovim 0.9.0 features
 - terminal colors
 - darker background for sidebar-like windows
+- light `day` variant (a light background, for daytime/light-mode use)
 - supports all major plugins
 
 ## ⚡️ Requirements
@@ -82,7 +83,25 @@ let g:lightline = {'colorscheme': 'electron_highlighter'}
 > ❗️ configuration needs to be set **BEFORE** loading the color scheme with
 > `colorscheme electron_highlighter`
 
-The theme comes in two styles: the default, and a darker variant `night`.
+The theme comes in three styles: the default (dark), a darker variant `night`, and a
+light variant `day`. Selecting `day` also switches Neovim to a light background
+(`vim.o.background = "light"`).
+
+```lua
+-- Light variant:
+require("electron_highlighter").setup({ style = "day" })
+vim.cmd.colorscheme("electron_highlighter")
+```
+
+Tip: if your shell exports the current OS/terminal theme (e.g. `CURRENT_THEME`), you can
+follow it automatically:
+
+```lua
+require("electron_highlighter").setup({
+  style = (os.getenv("CURRENT_THEME") == "electron_highlighter_day") and "day" or "default",
+})
+vim.cmd.colorscheme("electron_highlighter")
+```
 
 Electron Highlighter will use the default options, unless you call `setup`.
 

--- a/colors/electron_highlighter.lua
+++ b/colors/electron_highlighter.lua
@@ -1,1 +1,2 @@
-require("electron_highlighter")._load()
+local style = vim.env.CURRENT_THEME == "electron_highlighter_day" and "day" or nil
+require("electron_highlighter")._load(style)

--- a/colors/electron_highlighter.lua
+++ b/colors/electron_highlighter.lua
@@ -1,2 +1,1 @@
-local style = vim.env.CURRENT_THEME == "electron_highlighter_day" and "day" or nil
-require("electron_highlighter")._load(style)
+require("electron_highlighter")._load()

--- a/doc/electron_highlighter.nvim.txt
+++ b/doc/electron_highlighter.nvim.txt
@@ -104,7 +104,13 @@ CONFIGURATION                      *electron_highlighter.nvim-electron-highlight
 
   configuration needs to be set **BEFORE** loading the color scheme with
   `colorscheme electron_highlighter`
-The theme comes in two styles - the default, and a darker variant `night`.
+The theme comes in three styles - the default (dark), a darker variant `night`, and a
+light variant `day`. Selecting `day` also sets a light background
+(`vim.o.background = "light"`):
+>lua
+    require("electron_highlighter").setup({ style = "day" })
+    vim.cmd.colorscheme("electron_highlighter")
+<
 
 Electron Highlighter will use the default options, unless you call `setup`.
 

--- a/lua/electron_highlighter/colors.lua
+++ b/lua/electron_highlighter/colors.lua
@@ -150,9 +150,10 @@ function M.setup(opts)
   }
 
   colors.git.ignore = colors.dark3
-  colors.black = util.darken(colors.bg, 0.8, "#000000")
-  colors.border_highlight = util.darken(colors.blue1, 0.8)
-  colors.border = colors.black
+  local is_day = config.options.style == "day"
+  colors.black = is_day and "#1f2733" or util.darken(colors.bg, 0.8, "#000000")
+  colors.border_highlight = is_day and "#366ff0" or util.darken(colors.blue1, 0.8)
+  colors.border = is_day and "#d3d8e3" or colors.black
 
   -- Popups and statusline always get a dark background
   colors.bg_popup = colors.bg_dark

--- a/lua/electron_highlighter/colors.lua
+++ b/lua/electron_highlighter/colors.lua
@@ -87,6 +87,43 @@ M.night = {
   red1 = "#ff5874",
 }
 
+-- Light variant — Electron Highlighter Day. Values from the canonical palette
+-- (electron-highlighter/palette: electron-day.js). Light-appropriate supporting
+-- shades (blue0-7, dark3/5) are tuned for a light background.
+M.day = {
+  none = "NONE",
+  bg = "#eef0f5",
+  bg_dark = "#e4e7ee",
+  bg_highlight = "#dde3ee",
+  terminal_black = "#c2c6d4",
+  fg = "#2f3b54",
+  fg_dark = "#59647e",
+  fg_gutter = "#aab4c6",
+  comment = "#7b88a8",
+  blue = "#366ff0",
+  cyan = "#0a9fbf",
+  orange = "#f0633c",
+  yellow = "#d18a16",
+  green = "#10a877",
+  red = "#f52a65",
+  git = { add = "#10a877", change = "#d18a16", delete = "#f52a65" },
+  gitSigns = { add = "#10a877", change = "#d18a16", delete = "#f52a65" },
+  dark3 = "#aab4c6",
+  dark5 = "#8b95aa",
+  blue0 = "#c4d4f5",
+  blue1 = "#0a9fbf",
+  blue2 = "#2f6ee6",
+  blue5 = "#5f86e0",
+  blue6 = "#9bb5f5",
+  blue7 = "#b6c2e8",
+  magenta = "#8b4fe0",
+  magenta2 = "#e62b86",
+  teal = "#0e9488",
+  green1 = "#0c9b6e",
+  green2 = "#10a877",
+  red1 = "#e11d48",
+}
+
 ---@return ColorScheme
 function M.setup(opts)
   opts = opts or {}

--- a/lua/electron_highlighter/colors.lua
+++ b/lua/electron_highlighter/colors.lua
@@ -140,6 +140,7 @@ function M.setup(opts)
   local colors = vim.tbl_deep_extend("force", vim.deepcopy(M.default), palette)
 
   util.bg = colors.bg
+  util.fg = config.options.style == "day" and colors.fg or "#ffffff"
   util.day_brightness = config.options.day_brightness
 
   colors.diff = {

--- a/lua/electron_highlighter/config.lua
+++ b/lua/electron_highlighter/config.lua
@@ -4,7 +4,7 @@ local M = {}
 ---@field on_colors fun(colors: ColorScheme)
 ---@field on_highlights fun(highlights: Highlights, colors: ColorScheme)
 local defaults = {
-  style = "default", -- The theme comes in two styles - default, or a darker variant "night"
+  style = "default", -- The theme comes in three styles - "default", a darker variant "night", or a light variant "day" (sets background=light)
   transparent = false, -- Enable this to disable setting the background color
   terminal_colors = true, -- Configure the colors used when opening a `:terminal` in Neovim
   styles = {

--- a/lua/electron_highlighter/theme.lua
+++ b/lua/electron_highlighter/theme.lua
@@ -25,19 +25,23 @@ function M.setup()
 
   local c       = theme.colors
 
+  -- Day uses a blue cursor with the editor bg as the character under it; the
+  -- dark styles keep their original cursor groups.
+  local is_day  = options.style == "day"
+
   theme.highlights = {
     Foo                                        = { bg = c.magenta2, fg = c.fg },
 
     Comment                                    = { fg = c.comment, style = options.styles.comments }, -- any comment
     ColorColumn                                = { bg = c.black },                                    -- used for the columns set with 'colorcolumn'
     Conceal                                    = { fg = c.dark5 },                                    -- placeholder characters substituted for concealed text (see 'conceallevel')
-    Cursor                                     = { fg = c.bg, bg = c.blue },                            -- character under the cursor
+    Cursor                                     = is_day and { fg = c.bg, bg = c.blue } or { fg = c.bg, bg = c.fg }, -- character under the cursor
     -- cursors change color based on mode
-    CursorNormal                               = { bg = c.blue, fg = c.bg },
-    CursorVisual                               = { bg = c.magenta, fg = c.bg },
-    CursorInsert                               = { bg = c.green, fg = c.bg },
-    lCursor                                    = { fg = c.bg, bg = c.blue }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
-    CursorIM                                   = { fg = c.bg, bg = c.blue }, -- like Cursor, but used when in IME mode |CursorIM|
+    CursorNormal                               = is_day and { bg = c.blue, fg = c.bg } or { bg = c.fg_dark, fg = c.fg_dark },
+    CursorVisual                               = is_day and { bg = c.magenta, fg = c.bg } or { bg = c.magenta, fg = c.magenta },
+    CursorInsert                               = is_day and { bg = c.green, fg = c.bg } or { bg = c.green, fg = c.green },
+    lCursor                                    = is_day and { fg = c.bg, bg = c.blue } or { fg = c.bg, bg = c.fg }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
+    CursorIM                                   = is_day and { fg = c.bg, bg = c.blue } or { fg = c.bg, bg = c.fg }, -- like Cursor, but used when in IME mode |CursorIM|
     CursorColumn                               = { bg = c.bg_highlight },  -- Screen-column at the cursor, when 'cursorcolumn' is set.
     CursorLine                                 = { bg = c.bg_highlight },  -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
     Directory                                  = { fg = c.blue },          -- directory names (and other special names in listings)

--- a/lua/electron_highlighter/theme.lua
+++ b/lua/electron_highlighter/theme.lua
@@ -25,23 +25,19 @@ function M.setup()
 
   local c       = theme.colors
 
-  -- Character under the cursor: white on the light (day) theme for legibility,
-  -- the editor background on dark themes (which reads on the brighter accents).
-  local cursor_char = options.style == "day" and "#ffffff" or c.bg
-
   theme.highlights = {
     Foo                                        = { bg = c.magenta2, fg = c.fg },
 
     Comment                                    = { fg = c.comment, style = options.styles.comments }, -- any comment
     ColorColumn                                = { bg = c.black },                                    -- used for the columns set with 'colorcolumn'
     Conceal                                    = { fg = c.dark5 },                                    -- placeholder characters substituted for concealed text (see 'conceallevel')
-    Cursor                                     = { fg = cursor_char, bg = c.blue },                     -- character under the cursor
+    Cursor                                     = { fg = c.bg, bg = c.blue },                            -- character under the cursor
     -- cursors change color based on mode
-    CursorNormal                               = { bg = c.blue, fg = cursor_char },
-    CursorVisual                               = { bg = c.magenta, fg = cursor_char },
-    CursorInsert                               = { bg = c.green, fg = cursor_char },
-    lCursor                                    = { fg = cursor_char, bg = c.blue }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
-    CursorIM                                   = { fg = cursor_char, bg = c.blue }, -- like Cursor, but used when in IME mode |CursorIM|
+    CursorNormal                               = { bg = c.blue, fg = c.bg },
+    CursorVisual                               = { bg = c.magenta, fg = c.bg },
+    CursorInsert                               = { bg = c.green, fg = c.bg },
+    lCursor                                    = { fg = c.bg, bg = c.blue }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
+    CursorIM                                   = { fg = c.bg, bg = c.blue }, -- like Cursor, but used when in IME mode |CursorIM|
     CursorColumn                               = { bg = c.bg_highlight },  -- Screen-column at the cursor, when 'cursorcolumn' is set.
     CursorLine                                 = { bg = c.bg_highlight },  -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
     Directory                                  = { fg = c.blue },          -- directory names (and other special names in listings)

--- a/lua/electron_highlighter/theme.lua
+++ b/lua/electron_highlighter/theme.lua
@@ -25,19 +25,23 @@ function M.setup()
 
   local c       = theme.colors
 
+  -- Character under the cursor: white on the light (day) theme for legibility,
+  -- the editor background on dark themes (which reads on the brighter accents).
+  local cursor_char = options.style == "day" and "#ffffff" or c.bg
+
   theme.highlights = {
     Foo                                        = { bg = c.magenta2, fg = c.fg },
 
     Comment                                    = { fg = c.comment, style = options.styles.comments }, -- any comment
     ColorColumn                                = { bg = c.black },                                    -- used for the columns set with 'colorcolumn'
     Conceal                                    = { fg = c.dark5 },                                    -- placeholder characters substituted for concealed text (see 'conceallevel')
-    Cursor                                     = { fg = c.bg, bg = c.blue },                           -- character under the cursor
+    Cursor                                     = { fg = cursor_char, bg = c.blue },                     -- character under the cursor
     -- cursors change color based on mode
-    CursorNormal                               = { bg = c.blue, fg = c.bg },
-    CursorVisual                               = { bg = c.magenta, fg = c.bg },
-    CursorInsert                               = { bg = c.green, fg = c.bg },
-    lCursor                                    = { fg = c.bg, bg = c.blue }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
-    CursorIM                                   = { fg = c.bg, bg = c.blue }, -- like Cursor, but used when in IME mode |CursorIM|
+    CursorNormal                               = { bg = c.blue, fg = cursor_char },
+    CursorVisual                               = { bg = c.magenta, fg = cursor_char },
+    CursorInsert                               = { bg = c.green, fg = cursor_char },
+    lCursor                                    = { fg = cursor_char, bg = c.blue }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
+    CursorIM                                   = { fg = cursor_char, bg = c.blue }, -- like Cursor, but used when in IME mode |CursorIM|
     CursorColumn                               = { bg = c.bg_highlight },  -- Screen-column at the cursor, when 'cursorcolumn' is set.
     CursorLine                                 = { bg = c.bg_highlight },  -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
     Directory                                  = { fg = c.blue },          -- directory names (and other special names in listings)

--- a/lua/electron_highlighter/theme.lua
+++ b/lua/electron_highlighter/theme.lua
@@ -31,13 +31,13 @@ function M.setup()
     Comment                                    = { fg = c.comment, style = options.styles.comments }, -- any comment
     ColorColumn                                = { bg = c.black },                                    -- used for the columns set with 'colorcolumn'
     Conceal                                    = { fg = c.dark5 },                                    -- placeholder characters substituted for concealed text (see 'conceallevel')
-    Cursor                                     = { fg = c.bg, bg = c.fg },                            -- character under the cursor
+    Cursor                                     = { fg = c.bg, bg = c.blue },                           -- character under the cursor
     -- cursors change color based on mode
-    CursorNormal                               = { bg = c.fg_dark, fg = c.fg_dark },
-    CursorVisual                               = { bg = c.magenta, fg = c.magenta },
-    CursorInsert                               = { bg = c.green, fg = c.green },
-    lCursor                                    = { fg = c.bg, bg = c.fg }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
-    CursorIM                                   = { fg = c.bg, bg = c.fg }, -- like Cursor, but used when in IME mode |CursorIM|
+    CursorNormal                               = { bg = c.blue, fg = c.bg },
+    CursorVisual                               = { bg = c.magenta, fg = c.bg },
+    CursorInsert                               = { bg = c.green, fg = c.bg },
+    lCursor                                    = { fg = c.bg, bg = c.blue }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
+    CursorIM                                   = { fg = c.bg, bg = c.blue }, -- like Cursor, but used when in IME mode |CursorIM|
     CursorColumn                               = { bg = c.bg_highlight },  -- Screen-column at the cursor, when 'cursorcolumn' is set.
     CursorLine                                 = { bg = c.bg_highlight },  -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
     Directory                                  = { fg = c.blue },          -- directory names (and other special names in listings)

--- a/lua/electron_highlighter/util.lua
+++ b/lua/electron_highlighter/util.lua
@@ -187,6 +187,7 @@ function M.load(theme)
   end
 
   vim.o.termguicolors = true
+  vim.o.background = require("electron_highlighter.config").options.style == "day" and "light" or "dark"
   vim.g.colors_name = "electron_highlighter"
 
   if ts.new_style() then

--- a/tests/day_spec.lua
+++ b/tests/day_spec.lua
@@ -1,0 +1,39 @@
+-- Run: nvim --headless -u NONE --cmd "set rtp+=." -c "luafile tests/day_spec.lua" -c "qa"
+local function hl(group, attr)
+  local h = vim.api.nvim_get_hl(0, { name = group, link = false })
+  local v = h[attr]
+  return v and string.format("#%06x", v) or nil
+end
+
+require("electron_highlighter").setup({ style = "day" })
+require("electron_highlighter").load({ style = "day" })
+
+local checks = {
+  -- vim.o.background must be set to "light" by the day variant
+  { "vim.o.background", vim.o.background, "light" },
+  -- Normal: fg = c.fg (#2f3b54), bg = c.bg (#eef0f5)
+  { "Normal.bg", hl("Normal", "bg"), "#eef0f5" },
+  { "Normal.fg", hl("Normal", "fg"), "#2f3b54" },
+  -- Comment: fg = c.comment (#7b88a8)
+  { "Comment.fg", hl("Comment", "fg"), "#7b88a8" },
+  -- String: fg = c.green (#10a877)
+  { "String.fg", hl("String", "fg"), "#10a877" },
+  -- Constant: fg = c.orange (#f0633c)
+  { "Constant.fg", hl("Constant", "fg"), "#f0633c" },
+  -- Operator: fg = c.cyan (#0a9fbf)
+  { "Operator.fg", hl("Operator", "fg"), "#0a9fbf" },
+  -- Tag: fg = c.red (#f52a65)
+  { "Tag.fg", hl("Tag", "fg"), "#f52a65" },
+}
+
+local failed = 0
+for _, c in ipairs(checks) do
+  local name, got, want = c[1], c[2], c[3]
+  if got ~= want then
+    failed = failed + 1
+    print(string.format("FAIL %s: got %s want %s", name, tostring(got), want))
+  else
+    print(string.format("ok   %s = %s", name, want))
+  end
+end
+print(failed > 0 and ("DAY SPEC FAILED: " .. failed) or "DAY SPEC PASSED")

--- a/tests/day_spec.lua
+++ b/tests/day_spec.lua
@@ -24,6 +24,9 @@ local checks = {
   { "Operator.fg", hl("Operator", "fg"), "#0a9fbf" },
   -- Tag: fg = c.red (#f52a65)
   { "Tag.fg", hl("Tag", "fg"), "#f52a65" },
+  -- Cursor: blue block with a white character under it (day)
+  { "CursorNormal.bg", hl("CursorNormal", "bg"), "#366ff0" },
+  { "CursorNormal.fg", hl("CursorNormal", "fg"), "#ffffff" },
 }
 
 local failed = 0

--- a/tests/day_spec.lua
+++ b/tests/day_spec.lua
@@ -24,9 +24,9 @@ local checks = {
   { "Operator.fg", hl("Operator", "fg"), "#0a9fbf" },
   -- Tag: fg = c.red (#f52a65)
   { "Tag.fg", hl("Tag", "fg"), "#f52a65" },
-  -- Cursor: blue block with a white character under it (day)
+  -- Cursor: blue block with the editor bg as the character under it (day)
   { "CursorNormal.bg", hl("CursorNormal", "bg"), "#366ff0" },
-  { "CursorNormal.fg", hl("CursorNormal", "fg"), "#ffffff" },
+  { "CursorNormal.fg", hl("CursorNormal", "fg"), "#eef0f5" },
 }
 
 local failed = 0


### PR DESCRIPTION
Adds a light **day** style to the Neovim theme, selectable via `setup({ style = "day" })` (then `colorscheme electron_highlighter`). Matches the canonical Electron Highlighter Day palette used across the terminal/fish/Zed themes.

- New `M.day` palette in `colors.lua` (brand Day colors, not an HSLuv inversion).
- Day-aware derived neutrals (`black`/`border`/`border_highlight`) and sets `vim.o.background = "light"`; **dark styles are byte-identical** (every change guarded on `style == "day"`).
- Fixes washed-out `lighten()` syntax colors on light (e.g. parameters) by pointing `util.fg` at the theme fg for day.
- Day-only blue cursor with a readable character under it; dark cursor unchanged.
- Integrations (lightline/lualine/barbecue) need no changes — they read the resolved palette.
- Headless regression test in `tests/day_spec.lua`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)